### PR TITLE
feat: persist subscriptions and add notification integrations

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+
+export const prisma = globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/prisma/migrations/20250802180000_add_subscriptions/migration.sql
+++ b/prisma/migrations/20250802180000_add_subscriptions/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "subscriptions" (
+  "id" TEXT NOT NULL,
+  "filters" JSONB NOT NULL,
+  "webhookUrl" TEXT,
+  "email" TEXT,
+  "telegram" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "lastNotified" TIMESTAMP(3),
+  CONSTRAINT "subscriptions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "notification_logs" (
+  "id" TEXT NOT NULL,
+  "subscriptionId" TEXT NOT NULL,
+  "channel" TEXT NOT NULL,
+  "error" TEXT NOT NULL,
+  "attempts" INTEGER NOT NULL DEFAULT 1,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "notification_logs_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "notification_logs_subscriptionId_fkey" FOREIGN KEY ("subscriptionId") REFERENCES "subscriptions"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "notification_logs_subscriptionId_idx" ON "notification_logs"("subscriptionId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -235,6 +235,32 @@ model Watchlist {
   @@map("watchlists")
 }
 
+model Subscription {
+  id            String   @id @default(cuid())
+  filters       Json
+  webhookUrl    String?
+  email         String?
+  telegram      String?
+  createdAt     DateTime @default(now())
+  lastNotified  DateTime?
+  logs          NotificationLog[]
+
+  @@map("subscriptions")
+}
+
+model NotificationLog {
+  id             String   @id @default(cuid())
+  subscriptionId String
+  channel        String
+  error          String
+  attempts       Int      @default(1)
+  createdAt      DateTime @default(now())
+  subscription   Subscription @relation(fields: [subscriptionId], references: [id], onDelete: Cascade)
+
+  @@index([subscriptionId])
+  @@map("notification_logs")
+}
+
 // Alert/Notification ayarları
 model AlertSettings {
   id              String   @id @default(cuid())


### PR DESCRIPTION
## Summary
- persist subscriptions in Prisma and share data source between subscribe and notify APIs
- integrate SendGrid/Mailgun email and Telegram Bot notifications
- log failed notification attempts with retry helper and schema tables

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689839a88cd483308a896187c17e2efa