### PR TITLE
Use chain-specific explorers in token table

### DIFF
--- a/components/TokenTable.tsx
+++ b/components/TokenTable.tsx
@@ -1,18 +1,9 @@
 'use client'
 
-import { useEffect, useState } from "react"
-import * as Tooltip from "@radix-ui/react-tooltip"
+import { useState } from "react"
 import { LineChart, Line, ResponsiveContainer, XAxis, YAxis, Tooltip as RechartsTooltip } from "recharts"
-
-export type TokenEntry = {
-  chain: string
-  block: number
-  hash: string
-  from: string
-  timestamp: string
-  lp_status: string
-  price_chart: number[] | "none"
-}
+import type { TokenEntry } from "@/lib/fetchTokens"
+import { chainExplorers } from "@/lib/chains"
 
 type Props = {
   tokens: TokenEntry[]
@@ -50,46 +41,49 @@ export default function TokenTable({ tokens }: Props) {
           </tr>
         </thead>
         <tbody>
-          {filtered.map((t, i) => (
-            <tr key={i} className="border-t">
-              <td className="border p-2">{t.chain}</td>
-              <td className="border p-2">{t.block}</td>
-              <td className="border p-2 text-blue-500">
-                <a
-                  href={`https://basescan.org/tx/${t.hash}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {t.hash.slice(0, 8)}...
-                </a>
-              </td>
-              <td className="border p-2 text-blue-500">
-                <a
-                  href={`https://basescan.org/address/${t.from}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {t.from.slice(0, 6)}...
-                </a>
-              </td>
-              <td className="border p-2">{t.timestamp}</td>
-              <td className="border p-2">{t.lp_status}</td>
-              <td className="border p-2 w-32">
-                {Array.isArray(t.price_chart) && t.price_chart.length > 1 ? (
-                  <ResponsiveContainer width="100%" height={50}>
-                    <LineChart data={t.price_chart.map((y, i) => ({ x: i, y }))}>
-                      <Line type="monotone" dataKey="y" stroke="#8884d8" strokeWidth={2} dot={false} />
-                      <XAxis hide dataKey="x" />
-                      <YAxis hide domain={['auto', 'auto']} />
-                      <RechartsTooltip />
-                    </LineChart>
-                  </ResponsiveContainer>
-                ) : (
-                  <span className="text-gray-500 text-sm">No data</span>
-                )}
-              </td>
-            </tr>
-          ))}
+          {filtered.map((t, i) => {
+            const explorerUrl = t.explorerUrl || chainExplorers[t.chain] || '#'
+            return (
+              <tr key={i} className="border-t">
+                <td className="border p-2">{t.chain}</td>
+                <td className="border p-2">{t.block}</td>
+                <td className="border p-2 text-blue-500">
+                  <a
+                    href={`${explorerUrl}/tx/${t.hash}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {t.hash.slice(0, 8)}...
+                  </a>
+                </td>
+                <td className="border p-2 text-blue-500">
+                  <a
+                    href={`${explorerUrl}/address/${t.from}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {t.from.slice(0, 6)}...
+                  </a>
+                </td>
+                <td className="border p-2">{t.timestamp}</td>
+                <td className="border p-2">{t.lp_status}</td>
+                <td className="border p-2 w-32">
+                  {Array.isArray(t.price_chart) && t.price_chart.length > 1 ? (
+                    <ResponsiveContainer width="100%" height={50}>
+                      <LineChart data={t.price_chart.map((y, i) => ({ x: i, y }))}>
+                        <Line type="monotone" dataKey="y" stroke="#8884d8" strokeWidth={2} dot={false} />
+                        <XAxis hide dataKey="x" />
+                        <YAxis hide domain={['auto', 'auto']} />
+                        <RechartsTooltip />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  ) : (
+                    <span className="text-gray-500 text-sm">No data</span>
+                  )}
+                </td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
     </div>

--- a/lib/chains.ts
+++ b/lib/chains.ts
@@ -1,0 +1,13 @@
+export const chainExplorers: Record<string, string> = {
+  base: 'https://basescan.org',
+  optimism: 'https://optimistic.etherscan.io',
+  mode: 'https://explorer.mode.network',
+  zora: 'https://explorer.zora.energy',
+  arbitrum: 'https://arbiscan.io',
+  polygon: 'https://polygonscan.com',
+  ethereum: 'https://etherscan.io'
+};
+
+export const getExplorerUrl = (chain: string): string | undefined => {
+  return chainExplorers[chain];
+};

--- a/lib/fetchTokens.ts
+++ b/lib/fetchTokens.ts
@@ -1,5 +1,7 @@
 // lib/fetchTokens.ts
 
+import { chainExplorers } from './chains'
+
 export type TokenEntry = {
   chain: string
   block: number
@@ -7,10 +9,16 @@ export type TokenEntry = {
   from: string
   timestamp: string
   lp_status: string
+  price_chart: number[] | 'none'
+  explorerUrl: string
 }
 
 export async function fetchTokens(): Promise<TokenEntry[]> {
-  const res = await fetch("/base_tokenlar_lp.json")
-  if (!res.ok) throw new Error("Veri alınamadı")
-  return res.json()
+  const res = await fetch('/base_tokenlar_lp.json')
+  if (!res.ok) throw new Error('Veri alınamadı')
+  const data: Omit<TokenEntry, 'explorerUrl'>[] = await res.json()
+  return data.map((t) => ({
+    ...t,
+    explorerUrl: chainExplorers[t.chain] ?? ''
+  }))
 }


### PR DESCRIPTION
## Summary
- add central mapping of chains to explorer URLs
- attach explorer URLs to fetched token entries
- render token table links against each token's chain explorer

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (prompts for configuration)


------
https://chatgpt.com/codex/tasks/task_e_6898399ed51483309586e26995c4cd32