### PR TITLE
Validate block range and improve error handling

### DIFF
--- a/app/api/scan/route.ts
+++ b/app/api/scan/route.ts
@@ -215,8 +215,21 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const chain = searchParams.get('chain') || 'base';
-    const blocks = parseInt(searchParams.get('blocks') || '10');
+    const blocksParam = parseInt(searchParams.get('blocks') || '10', 10);
     const opStackOnly = searchParams.get('opStackOnly') === 'true';
+
+    // Validate blocks range (1-100)
+    if (isNaN(blocksParam) || blocksParam < 1 || blocksParam > 100) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Invalid blocks parameter: must be between 1 and 100'
+        },
+        { status: 400 }
+      );
+    }
+
+    const blocks = blocksParam;
 
     // Validate chain
     if (!chainConfigs[chain as keyof typeof chainConfigs]) {

--- a/components/TokenScanner.tsx
+++ b/components/TokenScanner.tsx
@@ -138,7 +138,7 @@ export default function TokenScanner() {
   const handleScan = async () => {
     setIsScanning(true);
     setError(null);
-    
+
     try {
       const response = await fetch(
         `/api/scan?chain=${selectedChain}&blocks=${blockCount}&opStackOnly=${opStackOnly}`,
@@ -149,17 +149,21 @@ export default function TokenScanner() {
           },
         }
       );
-      
+
+      const data: ScanResult | null = await response
+        .json()
+        .catch(() => null);
+
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+        setError(data?.error || `Request failed with status ${response.status}`);
+        setScanResults(null);
+        return;
       }
-      
-      const data: ScanResult = await response.json();
-      
-      if (data.success) {
+
+      if (data && data.success) {
         setScanResults(data);
       } else {
-        setError(data.error || 'Scan failed');
+        setError(data?.error || 'Scan failed');
       }
     } catch (err) {
       console.error('Scan error:', err);
@@ -300,7 +304,14 @@ export default function TokenScanner() {
               min="1"
               max="100"
               value={blockCount}
-              onChange={(e) => setBlockCount(parseInt(e.target.value) || 10)}
+              onChange={(e) => {
+                const value = parseInt(e.target.value, 10);
+                if (isNaN(value)) {
+                  setBlockCount(10);
+                } else {
+                  setBlockCount(Math.min(100, Math.max(1, value)));
+                }
+              }}
               disabled={isScanning}
               className="px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />


### PR DESCRIPTION
## Summary
- validate `blocks` query param to be 1–100 and return 400 with message
- surface backend error messages and clamp block input in TokenScanner UI

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68983992fd348330a242b9392b420584