### PR TITLE
refactor: centralize chain configs

### DIFF
--- a/app/api/analyze-token/route.ts
+++ b/app/api/analyze-token/route.ts
@@ -1,51 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ethers } from 'ethers';
-
-// Chain configurations with API keys
-const chainConfigs = {
-  base: { 
-    rpcUrl: process.env.BASE_RPC_URL || 'https://mainnet.base.org',
-    explorerUrl: 'https://basescan.org',
-    explorerApiUrl: 'https://api.basescan.org/api',
-    apiKey: process.env.BASESCAN_API_KEY || ''
-  },
-  optimism: { 
-    rpcUrl: process.env.OPTIMISM_RPC_URL || 'https://mainnet.optimism.io',
-    explorerUrl: 'https://optimistic.etherscan.io',
-    explorerApiUrl: 'https://api-optimistic.etherscan.io/api',
-    apiKey: process.env.OPTIMISM_API_KEY || ''
-  },
-  ethereum: { 
-    rpcUrl: process.env.ETHEREUM_RPC_URL || 'https://ethereum.publicnode.com',
-    explorerUrl: 'https://etherscan.io',
-    explorerApiUrl: 'https://api.etherscan.io/api',
-    apiKey: process.env.ETHERSCAN_API_KEY || ''
-  },
-  arbitrum: {
-    rpcUrl: process.env.ARBITRUM_RPC_URL || 'https://arbitrum.publicnode.com',
-    explorerUrl: 'https://arbiscan.io',
-    explorerApiUrl: 'https://api.arbiscan.io/api',
-    apiKey: process.env.ARBISCAN_API_KEY || ''
-  },
-  polygon: {
-    rpcUrl: process.env.POLYGON_RPC_URL || 'https://polygon.llamarpc.com',
-    explorerUrl: 'https://polygonscan.com',
-    explorerApiUrl: 'https://api.polygonscan.com/api',
-    apiKey: process.env.POLYGONSCAN_API_KEY || ''
-  },
-  mode: {
-    rpcUrl: process.env.MODE_RPC_URL || 'https://mainnet.mode.network',
-    explorerUrl: 'https://explorer.mode.network',
-    explorerApiUrl: 'https://explorer.mode.network/api',
-    apiKey: ''  // Mode doesn't use Etherscan API
-  },
-  zora: {
-    rpcUrl: process.env.ZORA_RPC_URL || 'https://rpc.zora.energy',
-    explorerUrl: 'https://explorer.zora.energy',
-    explorerApiUrl: 'https://explorer.zora.energy/api',
-    apiKey: ''  // Zora doesn't use Etherscan API
-  }
-};
+import { chainConfigs } from '@/lib/chains';
 
 // Enhanced ERC20 ABI for safety checks
 const SAFETY_CHECK_ABI = [

--- a/app/api/scan/route.ts
+++ b/app/api/scan/route.ts
@@ -1,80 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ethers } from 'ethers';
-import { saveTokenDeployment, saveScanHistory } from '@/lib/database';
-
-// Chain configurations with RPC endpoints
-const chainConfigs = {
-  base: {
-    name: 'base',
-    chainId: 8453,
-    rpcUrl: process.env.BASE_RPC_URL || 'https://mainnet.base.org',
-    explorerUrl: 'https://basescan.org',
-    isOpStack: true,
-    wethAddress: '0x4200000000000000000000000000000000000006',
-    uniswapV2Factory: '0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6',
-    uniswapV3Factory: '0x33128a8fC17869897dcE68Ed026d694621f6FDfD'
-  },
-  optimism: {
-    name: 'optimism',
-    chainId: 10,
-    rpcUrl: process.env.OPTIMISM_RPC_URL || 'https://mainnet.optimism.io',
-    explorerUrl: 'https://optimistic.etherscan.io',
-    isOpStack: true,
-    wethAddress: '0x4200000000000000000000000000000000000006',
-    uniswapV2Factory: '0x31F63A33141fFee63D4B26755430a390ACdD8a4d',
-    uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
-  },
-  mode: {
-    name: 'mode',
-    chainId: 34443,
-    rpcUrl: process.env.MODE_RPC_URL || 'https://mainnet.mode.network',
-    explorerUrl: 'https://explorer.mode.network',
-    isOpStack: true,
-    wethAddress: '0x4200000000000000000000000000000000000006',
-    uniswapV2Factory: '0x31F63A33141fFee63D4B26755430a390ACdD8a4d',
-    uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
-  },
-  zora: {
-    name: 'zora',
-    chainId: 7777777,
-    rpcUrl: process.env.ZORA_RPC_URL || 'https://rpc.zora.energy',
-    explorerUrl: 'https://explorer.zora.energy',
-    isOpStack: true,
-    wethAddress: '0x4200000000000000000000000000000000000006',
-    uniswapV2Factory: '0x31F63A33141fFee63D4B26755430a390ACdD8a4d',
-    uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
-  },
-  arbitrum: {
-    name: 'arbitrum',
-    chainId: 42161,
-    rpcUrl: process.env.ARBITRUM_RPC_URL || 'https://arb1.arbitrum.io/rpc',
-    explorerUrl: 'https://arbiscan.io',
-    isOpStack: false,
-    wethAddress: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
-    uniswapV2Factory: '0xf1D7CC64Fb4452F05c498126312eBE29f30Fbcf9',
-    uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
-  },
-  polygon: {
-    name: 'polygon',
-    chainId: 137,
-    rpcUrl: process.env.POLYGON_RPC_URL || 'https://polygon-rpc.com',
-    explorerUrl: 'https://polygonscan.com',
-    isOpStack: false,
-    wethAddress: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
-    uniswapV2Factory: '0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32',
-    uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
-  },
-  ethereum: {
-    name: 'ethereum',
-    chainId: 1,
-    rpcUrl: process.env.ETHEREUM_RPC_URL || 'https://ethereum.publicnode.com',
-    explorerUrl: 'https://etherscan.io',
-    isOpStack: false,
-    wethAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
-    uniswapV2Factory: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
-    uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
-  }
-};
+import { chainConfigs, ChainConfig } from '@/lib/chains';
 
 interface TokenContract {
   chain: string;
@@ -115,9 +41,9 @@ const scanCache = new Map<string, {
 const CACHE_DURATION = 60 * 1000; // 1 minute
 
 async function checkLiquidity(
-  tokenAddress: string, 
+  tokenAddress: string,
   provider: ethers.Provider,
-  chainConfig: typeof chainConfigs[keyof typeof chainConfigs]
+  chainConfig: ChainConfig
 ): Promise<{ v2: boolean; v3: boolean; status: string }> {
   try {
     let v2Exists = false;

--- a/components/TokenScanner.tsx
+++ b/components/TokenScanner.tsx
@@ -2,79 +2,10 @@
 
 import { useState, lazy, Suspense } from 'react';
 import DeployerLeaderboard from './DeployerLeaderboard';
+import { CHAINS } from '@/lib/chains';
 
 // Lazy load the safety analyzer to improve initial load time
 const TokenSafetyAnalyzer = lazy(() => import('./TokenSafetyAnalyzer'));
-
-interface ChainOption {
-  id: string;
-  name: string;
-  displayName: string;
-  color: string;
-  icon: string;
-  isOpStack: boolean;
-}
-
-const CHAINS: ChainOption[] = [
-  // OP Stack Chains
-  {
-    id: 'base',
-    name: 'base',
-    displayName: 'Base',
-    color: 'bg-blue-500',
-    icon: '🔵',
-    isOpStack: true
-  },
-  {
-    id: 'optimism',
-    name: 'optimism',
-    displayName: 'OP Mainnet',
-    color: 'bg-red-500',
-    icon: '🔴',
-    isOpStack: true
-  },
-  {
-    id: 'mode',
-    name: 'mode',
-    displayName: 'Mode',
-    color: 'bg-green-500',
-    icon: '🟢',
-    isOpStack: true
-  },
-  {
-    id: 'zora',
-    name: 'zora',
-    displayName: 'Zora',
-    color: 'bg-purple-500',
-    icon: '🟣',
-    isOpStack: true
-  },
-  // Other Chains
-  {
-    id: 'ethereum',
-    name: 'ethereum',
-    displayName: 'Ethereum',
-    color: 'bg-gray-700',
-    icon: '⟠',
-    isOpStack: false
-  },
-  {
-    id: 'arbitrum',
-    name: 'arbitrum',
-    displayName: 'Arbitrum',
-    color: 'bg-blue-600',
-    icon: '🔷',
-    isOpStack: false
-  },
-  {
-    id: 'polygon',
-    name: 'polygon',
-    displayName: 'Polygon',
-    color: 'bg-purple-600',
-    icon: '🟣',
-    isOpStack: false
-  }
-];
 
 export interface TokenContract {
   chain: string;

--- a/lib/chains.ts
+++ b/lib/chains.ts
@@ -1,0 +1,150 @@
+export interface ChainConfig {
+  id: string;
+  name: string;
+  displayName: string;
+  color: string;
+  icon: string;
+  chainId: number;
+  rpcUrl: string;
+  explorerUrl: string;
+  explorerApiUrl?: string;
+  apiKey?: string;
+  isOpStack: boolean;
+  wethAddress: string;
+  uniswapV2Factory: string;
+  uniswapV3Factory: string;
+}
+
+export const chainConfigs: Record<string, ChainConfig> = {
+  base: {
+    id: 'base',
+    name: 'base',
+    displayName: 'Base',
+    color: 'bg-blue-500',
+    icon: '🔵',
+    chainId: 8453,
+    rpcUrl: process.env.BASE_RPC_URL || 'https://mainnet.base.org',
+    explorerUrl: 'https://basescan.org',
+    explorerApiUrl: 'https://api.basescan.org/api',
+    apiKey: process.env.BASESCAN_API_KEY || '',
+    isOpStack: true,
+    wethAddress: '0x4200000000000000000000000000000000000006',
+    uniswapV2Factory: '0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6',
+    uniswapV3Factory: '0x33128a8fC17869897dcE68Ed026d694621f6FDfD'
+  },
+  optimism: {
+    id: 'optimism',
+    name: 'optimism',
+    displayName: 'OP Mainnet',
+    color: 'bg-red-500',
+    icon: '🔴',
+    chainId: 10,
+    rpcUrl: process.env.OPTIMISM_RPC_URL || 'https://mainnet.optimism.io',
+    explorerUrl: 'https://optimistic.etherscan.io',
+    explorerApiUrl: 'https://api-optimistic.etherscan.io/api',
+    apiKey: process.env.OPTIMISM_API_KEY || '',
+    isOpStack: true,
+    wethAddress: '0x4200000000000000000000000000000000000006',
+    uniswapV2Factory: '0x31F63A33141fFee63D4B26755430a390ACdD8a4d',
+    uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
+  },
+  mode: {
+    id: 'mode',
+    name: 'mode',
+    displayName: 'Mode',
+    color: 'bg-green-500',
+    icon: '🟢',
+    chainId: 34443,
+    rpcUrl: process.env.MODE_RPC_URL || 'https://mainnet.mode.network',
+    explorerUrl: 'https://explorer.mode.network',
+    explorerApiUrl: 'https://explorer.mode.network/api',
+    apiKey: '',
+    isOpStack: true,
+    wethAddress: '0x4200000000000000000000000000000000000006',
+    uniswapV2Factory: '0x31F63A33141fFee63D4B26755430a390ACdD8a4d',
+    uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
+  },
+  zora: {
+    id: 'zora',
+    name: 'zora',
+    displayName: 'Zora',
+    color: 'bg-purple-500',
+    icon: '🟣',
+    chainId: 7777777,
+    rpcUrl: process.env.ZORA_RPC_URL || 'https://rpc.zora.energy',
+    explorerUrl: 'https://explorer.zora.energy',
+    explorerApiUrl: 'https://explorer.zora.energy/api',
+    apiKey: '',
+    isOpStack: true,
+    wethAddress: '0x4200000000000000000000000000000000000006',
+    uniswapV2Factory: '0x31F63A33141fFee63D4B26755430a390ACdD8a4d',
+    uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
+  },
+  ethereum: {
+    id: 'ethereum',
+    name: 'ethereum',
+    displayName: 'Ethereum',
+    color: 'bg-gray-700',
+    icon: '⟠',
+    chainId: 1,
+    rpcUrl: process.env.ETHEREUM_RPC_URL || 'https://ethereum.publicnode.com',
+    explorerUrl: 'https://etherscan.io',
+    explorerApiUrl: 'https://api.etherscan.io/api',
+    apiKey: process.env.ETHERSCAN_API_KEY || '',
+    isOpStack: false,
+    wethAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+    uniswapV2Factory: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
+    uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
+  },
+  arbitrum: {
+    id: 'arbitrum',
+    name: 'arbitrum',
+    displayName: 'Arbitrum',
+    color: 'bg-blue-600',
+    icon: '🔷',
+    chainId: 42161,
+    rpcUrl: process.env.ARBITRUM_RPC_URL || 'https://arb1.arbitrum.io/rpc',
+    explorerUrl: 'https://arbiscan.io',
+    explorerApiUrl: 'https://api.arbiscan.io/api',
+    apiKey: process.env.ARBISCAN_API_KEY || '',
+    isOpStack: false,
+    wethAddress: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
+    uniswapV2Factory: '0xf1D7CC64Fb4452F05c498126312eBE29f30Fbcf9',
+    uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
+  },
+  polygon: {
+    id: 'polygon',
+    name: 'polygon',
+    displayName: 'Polygon',
+    color: 'bg-purple-600',
+    icon: '🟣',
+    chainId: 137,
+    rpcUrl: process.env.POLYGON_RPC_URL || 'https://polygon-rpc.com',
+    explorerUrl: 'https://polygonscan.com',
+    explorerApiUrl: 'https://api.polygonscan.com/api',
+    apiKey: process.env.POLYGONSCAN_API_KEY || '',
+    isOpStack: false,
+    wethAddress: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+    uniswapV2Factory: '0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32',
+    uniswapV3Factory: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
+  }
+};
+
+export interface ChainOption {
+  id: string;
+  name: string;
+  displayName: string;
+  color: string;
+  icon: string;
+  isOpStack: boolean;
+}
+
+export const CHAINS: ChainOption[] = Object.values(chainConfigs).map(({ id, name, displayName, color, icon, isOpStack }) => ({
+  id,
+  name,
+  displayName,
+  color,
+  icon,
+  isOpStack
+}));
+


### PR DESCRIPTION
## Summary
- centralize chain configuration data into `lib/chains.ts`
- import shared chain configs in API routes and token scanner
- remove duplicate chain option declarations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6898397f524c83309629441f0e3382e2