### PR TITLE
refactor: modularize portfolio tracker

### DIFF
--- a/components/portfolio/AddTokenModal.tsx
+++ b/components/portfolio/AddTokenModal.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useState } from "react"
+
+interface Holding {
+  symbol: string
+  amount: number
+  value: number
+}
+
+interface Props {
+  isOpen: boolean
+  onAdd: (holding: Holding) => void
+  onClose: () => void
+}
+
+export default function AddTokenModal({ isOpen, onAdd, onClose }: Props) {
+  const [symbol, setSymbol] = useState('')
+  const [amount, setAmount] = useState(0)
+
+  if (!isOpen) return null
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onAdd({ symbol, amount, value: 0 })
+    setSymbol('')
+    setAmount(0)
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg space-y-4 w-80">
+        <h3 className="text-lg font-semibold">Add Token</h3>
+        <input
+          value={symbol}
+          onChange={e => setSymbol(e.target.value)}
+          placeholder="Symbol"
+          className="w-full border p-2 rounded"
+        />
+        <input
+          type="number"
+          value={amount}
+          onChange={e => setAmount(parseFloat(e.target.value))}
+          placeholder="Amount"
+          className="w-full border p-2 rounded"
+        />
+        <div className="flex justify-end space-x-2">
+          <button type="button" onClick={onClose} className="px-4 py-2 rounded bg-gray-200">
+            Cancel
+          </button>
+          <button type="submit" className="px-4 py-2 rounded bg-blue-600 text-white">
+            Add
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/components/portfolio/AllocationChart.tsx
+++ b/components/portfolio/AllocationChart.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts"
+
+interface AllocationItem {
+  name: string
+  value: number
+}
+
+const COLORS = ['#2563eb', '#9333ea', '#16a34a', '#f59e0b', '#dc2626']
+
+export default function AllocationChart({ data }: { data: AllocationItem[] }) {
+  return (
+    <div className="h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie data={data} dataKey="value" nameKey="name" outerRadius={80} label>
+            {data.map((_, index) => (
+              <Cell key={index} fill={COLORS[index % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/components/portfolio/HoldingsTable.tsx
+++ b/components/portfolio/HoldingsTable.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+interface Holding {
+  symbol: string
+  amount: number
+  value: number
+}
+
+export default function HoldingsTable({ holdings }: { holdings: Holding[] }) {
+  return (
+    <table className="min-w-full divide-y divide-gray-200">
+      <thead>
+        <tr>
+          <th className="px-4 py-2 text-left text-sm font-medium">Token</th>
+          <th className="px-4 py-2 text-right text-sm font-medium">Amount</th>
+          <th className="px-4 py-2 text-right text-sm font-medium">Value ($)</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-gray-200">
+        {holdings.map(h => (
+          <tr key={h.symbol}>
+            <td className="px-4 py-2">{h.symbol}</td>
+            <td className="px-4 py-2 text-right">{h.amount}</td>
+            <td className="px-4 py-2 text-right">{h.value.toFixed(2)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/components/portfolio/PerformanceChart.tsx
+++ b/components/portfolio/PerformanceChart.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts"
+
+interface PerformancePoint {
+  date: string
+  value: number
+}
+
+export default function PerformanceChart({ data }: { data: PerformancePoint[] }) {
+  return (
+    <div className="h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data}>
+          <XAxis dataKey="date" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="#2563eb" strokeWidth={2} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/components/portfolio/PerformanceHighlights.tsx
+++ b/components/portfolio/PerformanceHighlights.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+interface Highlight {
+  label: string
+  value: string
+}
+
+export default function PerformanceHighlights({ highlights }: { highlights: Highlight[] }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+      {highlights.map((h, i) => (
+        <div key={i} className="p-4 border rounded-lg">
+          <p className="text-sm text-gray-500">{h.label}</p>
+          <p className="text-xl font-semibold">{h.value}</p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/portfolio/PortfolioTracker.tsx
+++ b/components/portfolio/PortfolioTracker.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useState } from "react"
+import StatsHeader from "@/components/portfolio/StatsHeader"
+import PerformanceChart from "@/components/portfolio/PerformanceChart"
+import AllocationChart from "@/components/portfolio/AllocationChart"
+import HoldingsTable from "@/components/portfolio/HoldingsTable"
+import AddTokenModal from "@/components/portfolio/AddTokenModal"
+import PerformanceHighlights from "@/components/portfolio/PerformanceHighlights"
+
+interface Holding {
+  symbol: string
+  amount: number
+  value: number
+}
+
+interface Stats {
+  totalValue: number
+  totalChange: number
+}
+
+interface PerformancePoint {
+  date: string
+  value: number
+}
+
+interface AllocationItem {
+  name: string
+  value: number
+}
+
+interface Highlight {
+  label: string
+  value: string
+}
+
+export default function PortfolioTracker() {
+  const [portfolio, setPortfolio] = useState<Holding[]>([
+    { symbol: 'ETH', amount: 1, value: 3200 },
+    { symbol: 'OP', amount: 500, value: 900 }
+  ])
+
+  const [stats] = useState<Stats>({
+    totalValue: portfolio.reduce((sum, h) => sum + h.value, 0),
+    totalChange: 2.5
+  })
+
+  const [performanceData] = useState<PerformancePoint[]>([
+    { date: 'Mon', value: 1000 },
+    { date: 'Tue', value: 1200 },
+    { date: 'Wed', value: 1300 },
+    { date: 'Thu', value: 1250 },
+    { date: 'Fri', value: 1500 }
+  ])
+
+  const [allocationData] = useState<AllocationItem[]>([
+    { name: 'ETH', value: 3200 },
+    { name: 'OP', value: 900 }
+  ])
+
+  const [highlights] = useState<Highlight[]>([
+    { label: 'Best Performer', value: 'ETH' },
+    { label: 'Worst Performer', value: 'OP' },
+    { label: 'New Tokens', value: '0' }
+  ])
+
+  const [isModalOpen, setModalOpen] = useState(false)
+
+  const handleAddToken = (holding: Holding) => {
+    setPortfolio([...portfolio, holding])
+  }
+
+  return (
+    <div className="space-y-6">
+      <StatsHeader stats={stats} />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <PerformanceChart data={performanceData} />
+        <AllocationChart data={allocationData} />
+      </div>
+
+      <HoldingsTable holdings={portfolio} />
+
+      <PerformanceHighlights highlights={highlights} />
+
+      <button
+        onClick={() => setModalOpen(true)}
+        className="mt-4 px-4 py-2 bg-blue-600 text-white rounded"
+      >
+        Add Token
+      </button>
+
+      <AddTokenModal
+        isOpen={isModalOpen}
+        onAdd={handleAddToken}
+        onClose={() => setModalOpen(false)}
+      />
+    </div>
+  )
+}

--- a/components/portfolio/StatsHeader.tsx
+++ b/components/portfolio/StatsHeader.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+interface PortfolioStats {
+  totalValue: number
+  totalChange: number
+}
+
+export default function StatsHeader({ stats }: { stats: PortfolioStats }) {
+  return (
+    <div className="mb-4">
+      <h2 className="text-2xl font-bold">
+        Portfolio Value: ${stats.totalValue.toFixed(2)}
+      </h2>
+      <p className="text-sm text-gray-600">
+        24h Change: {stats.totalChange.toFixed(2)}%
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- split PortfolioTracker into modular components for stats, charts, holdings, and modal
- wire up props and callbacks between PortfolioTracker and new subcomponents

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_689efbe8c5f08330bd0c36f31b77d82d